### PR TITLE
Fixed dimensional inconsistency

### DIFF
--- a/src/turtlebot_example/src/turtlebot_example_node.cpp
+++ b/src/turtlebot_example/src/turtlebot_example_node.cpp
@@ -27,7 +27,7 @@ void goal_d(double x_t,double y_t, double t)
 {
 	err_x=x_t-X;
 	err_y=y_t-Y;
-	err_d=sqrt(err_x*err_x+err_y+err_y);
+	err_d=sqrt(err_x*err_x+err_y*err_y);
 	err_yaw=t-yaw_degrees;
 	//if(err_yaw<0)err_yaw=err_yaw+360;
 	


### PR DESCRIPTION
Hello LordBismaya, 

I'm JP, a grad student studying ROS software.    My tool *phys* detected a line of code that appears to be accidently adding 'meters' to 'meters-squared'.   

the proposed change is from '+' to '*'.

Here's a link to the tool, if you're curious.  

In any case, Cheers

Automatically detected physical unit inconsistency using https://unl-nimbus-lab.github.io/phys/